### PR TITLE
Escaping parameters

### DIFF
--- a/proxy/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/proxy/rootfs/etc/nginx/includes/proxy_params.conf
@@ -6,12 +6,12 @@ proxy_send_timeout          86400s;
 proxy_max_temp_file_size    0;
 
 proxy_set_header Accept-Encoding "";
-proxy_set_header Connection $connection_upgrade;
-proxy_set_header Host $http_host;
-proxy_set_header Upgrade $http_upgrade;
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header Connection \$connection_upgrade;
+proxy_set_header Host \$http_host;
+proxy_set_header Upgrade \$http_upgrade;
+proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto \$scheme;
 proxy_set_header X-NginX-Proxy true;
-proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Real-IP \$remote_addr;
 
 


### PR DESCRIPTION
Got this in logfile in home assistant: 

[08:52:06] INFO: Starting NGINX...
nginx: [emerg] invalid number of arguments in "proxy_set_header" directive in /etc/nginx/servers/ingress.conf:11

And according to this site, escaping the params is the way to go..

https://stackoverflow.com/questions/66720740/homestead-and-nginx-error-emerg-invalid-number-of-arguments-in-proxy-set-head